### PR TITLE
Fix to use a valid client identifier for IBC

### DIFF
--- a/pkg/ibc/client/client.go
+++ b/pkg/ibc/client/client.go
@@ -3,7 +3,7 @@ package client
 // client type
 const (
 	// IBFT2 Client
-	BesuIBFT2Client = "ibft2"
+	BesuIBFT2Client = "hyperledger-besu-ibft2"
 	// NOTE: The mock client is only intended for use in development such as ganache.
-	MockClient = "mock"
+	MockClient = "mock-client"
 )


### PR DESCRIPTION
Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>

In ics-024, the length of Client identifier must be greater than or equal to 9.

ref. 
https://github.com/cosmos/ibc/tree/master/spec/core/ics-024-host-requirements#paths-identifiers-separators
https://github.com/cosmos/ibc-go/blob/fa091bcda3b1dbbf687ff4465f9fd309a4206e67/modules/core/24-host/validate.go#L61