### PR TITLE
Use int32 type instead of int64 as enum

### DIFF
--- a/contracts/core/types/Channel.sol
+++ b/contracts/core/types/Channel.sol
@@ -18,7 +18,7 @@ library Channel {
 
 
   // Solidity enum encoder
-  function encode_State(State x) internal pure returns (int64) {
+  function encode_State(State x) internal pure returns (int32) {
     
     if (x == State.STATE_UNINITIALIZED_UNSPECIFIED) {
       return 0;
@@ -78,7 +78,7 @@ library Channel {
 
 
   // Solidity enum encoder
-  function encode_Order(Order x) internal pure returns (int64) {
+  function encode_Order(Order x) internal pure returns (int32) {
     
     if (x == Order.ORDER_NONE_UNSPECIFIED) {
       return 0;
@@ -454,7 +454,7 @@ library Channel {
       pointer,
       bs
     );
-    int64 _enum_state = encode_State(r.state);
+    int32 _enum_state = encode_State(r.state);
     pointer += ProtoBufRuntime._encode_enum(_enum_state, pointer, bs);
     }
     if (uint(r.ordering) != 0) {
@@ -464,7 +464,7 @@ library Channel {
       pointer,
       bs
     );
-    int64 _enum_ordering = encode_Order(r.ordering);
+    int32 _enum_ordering = encode_Order(r.ordering);
     pointer += ProtoBufRuntime._encode_enum(_enum_ordering, pointer, bs);
     }
     
@@ -1344,7 +1344,7 @@ library ChannelIdentifiedChannel {
       pointer,
       bs
     );
-    int64 _enum_state = Channel.encode_State(r.state);
+    int32 _enum_state = Channel.encode_State(r.state);
     pointer += ProtoBufRuntime._encode_enum(_enum_state, pointer, bs);
     }
     if (uint(r.ordering) != 0) {
@@ -1354,7 +1354,7 @@ library ChannelIdentifiedChannel {
       pointer,
       bs
     );
-    int64 _enum_ordering = Channel.encode_Order(r.ordering);
+    int32 _enum_ordering = Channel.encode_Order(r.ordering);
     pointer += ProtoBufRuntime._encode_enum(_enum_ordering, pointer, bs);
     }
     

--- a/contracts/core/types/Connection.sol
+++ b/contracts/core/types/Connection.sol
@@ -16,7 +16,7 @@ library ConnectionEnd {
 
 
   // Solidity enum encoder
-  function encode_State(State x) internal pure returns (int64) {
+  function encode_State(State x) internal pure returns (int32) {
     
     if (x == State.STATE_UNINITIALIZED_UNSPECIFIED) {
       return 0;
@@ -438,7 +438,7 @@ library ConnectionEnd {
       pointer,
       bs
     );
-    int64 _enum_state = encode_State(r.state);
+    int32 _enum_state = encode_State(r.state);
     pointer += ProtoBufRuntime._encode_enum(_enum_state, pointer, bs);
     }
     if (r.delay_period != 0) {

--- a/contracts/core/types/ProtoBufRuntime.sol
+++ b/contracts/core/types/ProtoBufRuntime.sol
@@ -728,12 +728,12 @@ library ProtoBufRuntime {
     return _encode_varint(twosComplement, p, bs);
   }
 
-  function _encode_enum(int64 x, uint256 p, bytes memory bs)
+  function _encode_enum(int32 x, uint256 p, bytes memory bs)
     internal
     pure
     returns (uint256)
   {
-    return _encode_int64(x, p, bs);
+    return _encode_int32(x, p, bs);
   }
 
   function _encode_bool(bool x, uint256 p, bytes memory bs)


### PR DESCRIPTION
The version of the generator we used is https://github.com/datachainlab/solidity-protobuf/commit/da30d37593cb7ccd50234ebea8f0cc27e2aef400

ref. https://developers.google.com/protocol-buffers/docs/proto3#enum

Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>