### PR TITLE
Fix IBCHeight.toUint128

### DIFF
--- a/contracts/core/IBCHeight.sol
+++ b/contracts/core/IBCHeight.sol
@@ -5,7 +5,7 @@ import "./types/Client.sol";
 
 library IBCHeight {
     function toUint128(Height.Data memory self) internal pure returns (uint128) {
-        return uint128(self.revision_number) << 64 + uint128(self.revision_height);
+        return (uint128(self.revision_number) << 64) | uint128(self.revision_height);
     }
 
     function isZero(Height.Data memory self) internal pure returns (bool) {


### PR DESCRIPTION
Fix a bug related to operator precedence.
https://docs.soliditylang.org/en/v0.8.9/cheatsheet.html

`x << 64 + y` means `x << (64 + y)`, not `(x << 64) + y`.