### PR TITLE
02-client-refactor added support for multiple consensus states inside a header

### DIFF
--- a/contracts/core/IBCMsgs.sol
+++ b/contracts/core/IBCMsgs.sol
@@ -21,7 +21,7 @@ library IBCMsgs {
 
     struct MsgUpdateClient {
         string clientId;
-        bytes header;
+        bytes clientMessage;
     }
 
     /// Connection handshake ///

--- a/contracts/core/IClient.sol
+++ b/contracts/core/IClient.sol
@@ -20,12 +20,12 @@ interface IClient {
         string calldata clientId
     ) external view returns (Height.Data memory, bool);
 
-    function checkHeaderAndUpdateState(
+    function verifyClientMessageAndUpdateState(
         IBCHost host,
-        string calldata clientId, 
+        string calldata clientId,
         bytes calldata clientStateBytes,
-        bytes calldata headerBytes
-    ) external returns (bytes memory newClientStateBytes, bytes memory newConsensusStateBytes, Height.Data memory height);
+        bytes calldata clientMessageBytes
+    ) external returns (bool);
 
     function verifyClientState(
         IBCHost host,


### PR DESCRIPTION
A beefy or grandpa header submitted on-chain can potentially contain headers with multiple consensus states. This PR refactors the client interface to support beefy and grandpa light clients.