### PR TITLE
Update openzepplin-solidity to @openzepplin/contracts

### DIFF
--- a/contracts/app/ICS20Bank.sol
+++ b/contracts/app/ICS20Bank.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.9;
 
-import "openzeppelin-solidity/contracts/utils/Context.sol";
-import "openzeppelin-solidity/contracts/access/AccessControl.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "openzeppelin-solidity/contracts/utils/Address.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/access/AccessControl.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 import "./IICS20Bank.sol";
 
 contract ICS20Bank is Context, AccessControl, IICS20Bank {

--- a/contracts/app/ICS20Transfer.sol
+++ b/contracts/app/ICS20Transfer.sol
@@ -9,7 +9,7 @@ import "../core/IBCHost.sol";
 import "../proto/App.sol";
 import "../lib/strings.sol";
 import "../lib/Bytes.sol";
-import "openzeppelin-solidity/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 
 abstract contract ICS20Transfer is Context, IICS20Transfer {
     using strings for *;

--- a/contracts/app/SimpleToken.sol
+++ b/contracts/app/SimpleToken.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.9;
 
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract SimpleToken is ERC20 {
     constructor(string memory name, string memory symbol, uint256 initSupply) ERC20(name, symbol) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "hasInstallScript": true,
       "license": "Apache2.0",
       "dependencies": {
+        "@openzeppelin/contracts": "^4.8.0",
         "@truffle/hdwallet-provider": "^2.0.15",
         "ejs": "^3.1.7",
-        "openzeppelin-solidity": "^4.3.2",
         "truffle": "5.1.58",
         "truffle-contract-size": "^2.0.1"
       }
@@ -564,6 +564,11 @@
           "url": "https://paulmillr.com/funding/"
         }
       ]
+    },
+    "node_modules/@openzeppelin/contracts": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
+      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw=="
     },
     "node_modules/@scure/base": {
       "version": "1.1.1",
@@ -3618,15 +3623,6 @@
         "wrappy": "1"
       }
     },
-    "node_modules/openzeppelin-solidity": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-4.3.2.tgz",
-      "integrity": "sha512-k20olEz9A58yq3zwFZgOJoe9vWodKaFsMjajpou1NiqzuxuDfIdaGL3/xLcn/48J0AmvqsxHrcgI3WHq370J+w==",
-      "deprecated": "This package is now published as @openzeppelin/contracts. Please change your dependency.",
-      "bin": {
-        "openzeppelin-contracts-migrate-imports": "scripts/migrate-imports.js"
-      }
-    },
     "node_modules/original-require": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/original-require/-/original-require-1.0.1.tgz",
@@ -5505,6 +5501,11 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
       "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
+    },
+    "@openzeppelin/contracts": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.0.tgz",
+      "integrity": "sha512-AGuwhRRL+NaKx73WKRNzeCxOCOCxpaqF+kp8TJ89QzAipSwZy/NoflkWaL9bywXFRhIzXt8j38sfF7KBKCPWLw=="
     },
     "@scure/base": {
       "version": "1.1.1",
@@ -8019,11 +8020,6 @@
       "requires": {
         "wrappy": "1"
       }
-    },
-    "openzeppelin-solidity": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-4.3.2.tgz",
-      "integrity": "sha512-k20olEz9A58yq3zwFZgOJoe9vWodKaFsMjajpou1NiqzuxuDfIdaGL3/xLcn/48J0AmvqsxHrcgI3WHq370J+w=="
     },
     "original-require": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "@truffle/hdwallet-provider": "^2.0.15",
     "ejs": "^3.1.7",
-    "openzeppelin-solidity": "^4.3.2",
+    "@openzeppelin/contracts": "^4.8.0",
     "truffle": "5.1.58",
     "truffle-contract-size": "^2.0.1"
   },

--- a/tests/foundry/src/MockApp.sol
+++ b/tests/foundry/src/MockApp.sol
@@ -8,7 +8,7 @@ import "../../../contracts/core/IBCHost.sol";
 import "../../../contracts/proto/App.sol";
 import "../../../contracts/lib/strings.sol";
 import "../../../contracts/lib/Bytes.sol";
-import "openzeppelin-solidity/contracts/utils/Context.sol";
+import "@openzeppelin/contracts/utils/Context.sol";
 
 contract MockApp is IModuleCallbacks {
     event MockRecv(bool ok);


### PR DESCRIPTION
Since openzepplin-solidity is deprecated as part of NPM documentation

https://www.npmjs.com/package/openzeppelin-solidity

Signed-off-by: Jinank Jain <jinank94@gmail.com>