### PR TITLE
e2e: specify a counterparty's height  instead of source's as packet timeout

### DIFF
--- a/tests/e2e/chains_test.go
+++ b/tests/e2e/chains_test.go
@@ -123,7 +123,7 @@ func (suite ChainTestSuite) TestChannel() {
 			100,
 			chainB.CallOpts(ctx, bobB).From,
 			chanA.PortID, chanA.ID,
-			uint64(chainA.LastHeader().Number.Int64())+1000,
+			uint64(chainB.LastHeader().Number.Int64())+1000,
 		),
 	))
 	chainA.UpdateHeader()
@@ -195,7 +195,7 @@ func (suite ChainTestSuite) TestChannel() {
 			chainA.CallOpts(ctx, aliceA).From,
 			chanB.PortID,
 			chanB.ID,
-			uint64(chainB.LastHeader().Number.Int64())+1000,
+			uint64(chainA.LastHeader().Number.Int64())+1000,
 		),
 	))
 	chainB.UpdateHeader()


### PR DESCRIPTION
Signed-off-by: Jun Kimura <jun.kimura@datachain.jp>