### PR TITLE
Check denom length on sendTransfer

### DIFF
--- a/contracts/apps/20-transfer/ICS20TransferBank.sol
+++ b/contracts/apps/20-transfer/ICS20TransferBank.sol
@@ -38,7 +38,8 @@ contract ICS20TransferBank is ICS20Transfer {
     ) external {
         require(ICS20Lib.isEscapedJSONString(receiver), "unescaped receiver");
         bytes memory denomPrefix = _getDenomPrefix(sourcePort, sourceChannel);
-        if (!bytes(denom).slice(0, denomPrefix.length).equal(denomPrefix)) {
+        bytes memory denomBytes = bytes(denom);
+        if (denomBytes.length < denomPrefix.length || !denomBytes.slice(0, denomPrefix.length).equal(denomPrefix)) {
             // sender is source chain
             require(_transferFrom(_msgSender(), _getEscrowAddress(sourceChannel), denom, amount));
         } else {


### PR DESCRIPTION
`slice_outOfBounds` occurs when the `denom` is shorter than the `denomPrefix`, so the length of the `denom` is checked.