### PR TITLE
update AppBase inheritance

### DIFF
--- a/contracts/apps/commons/IBCAppBase.sol
+++ b/contracts/apps/commons/IBCAppBase.sol
@@ -7,7 +7,7 @@ import {Packet} from "../../core/04-channel/IIBCChannel.sol";
 import {IIBCModule} from "../../core/26-router/IIBCModule.sol";
 import {IIBCModuleErrors} from "../../core/26-router/IIBCModuleErrors.sol";
 
-abstract contract AppBase is IERC165, Context, IIBCModuleErrors {
+abstract contract AppBase is Context, IERC165, IIBCModuleErrors {
     /**
      * @dev Throws if called by any account other than the IBC contract.
      */

--- a/contracts/core/04-channel/IBCChannelPacketSendRecv.sol
+++ b/contracts/core/04-channel/IBCChannelPacketSendRecv.sol
@@ -110,8 +110,9 @@ contract IBCChannelPacketSendRecv is
         ChannelStorage storage channelStorage =
             getChannelStorage()[msg_.packet.destinationPort][msg_.packet.destinationChannel];
         Channel.Data storage channel = channelStorage.channel;
-        if (channel.state == Channel.State.STATE_OPEN) {}
-        else if (channel.state == Channel.State.STATE_FLUSHING || channel.state == Channel.State.STATE_FLUSHCOMPLETE) {
+        if (channel.state == Channel.State.STATE_OPEN) {} else if (
+            channel.state == Channel.State.STATE_FLUSHING || channel.state == Channel.State.STATE_FLUSHCOMPLETE
+        ) {
             RecvStartSequence storage rseq = channelStorage.recvStartSequence;
             // prevSequence=0 means the channel is not in the process of being upgraded or counterparty has not been upgraded yet
             if (rseq.prevSequence != 0) {


### PR DESCRIPTION
This PR updates the inheritance order of AppBase to make it easier for App-layer contracts that inherit from AppBase to utilize OpenZeppelin contracts (such as AccessControl).